### PR TITLE
mc-analyzer fixes

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -71,7 +71,6 @@ sudo apt install         \
 
 ```bash
 npm install --prefix ./mc-analyzer
-sudo npm install -g ts-node typescript
 ```
 
 ### 6. Сборка проекта 

--- a/mc-analyzer/src/app/luna-ast.ts
+++ b/mc-analyzer/src/app/luna-ast.ts
@@ -65,7 +65,7 @@ export const CondNode = (begin: number) => (value: string | readonly [string, ..
             } else {
                 writeFileSync(workFile, `sub main() { foo(${' '.repeat(begin-17)}${value}); }`);
             }
-            execSync(`parser -o ${jsonFile} ${workFile}`);
+            execSync(`${process.env.LUNA_HOME}/bin/parser -o ${jsonFile} ${workFile}`);
             const x = JSON.parse(readFileSync(jsonFile, 'utf8'))['main'].body[1].args[0];
             cache.set(value, x);
             return x;

--- a/mc-analyzer/src/app/main.ts
+++ b/mc-analyzer/src/app/main.ts
@@ -236,12 +236,8 @@ const config = pipe(
 );
 
 const createPromelaBin = (promelaAST: TPromelaAST) => {
-    let code = promelaAST.promelaCode;
-    // Fix empty main proctype for spin
-    if (code.includes('active proctype main() {\n\n}')) {
-        code = code.replace('active proctype main() {\n\n}', 'active proctype main() {\n    skip;\n}');
-    }
-    writeText(path.join(config.workDir, 'verification.pml'))(code);
+    // console.log(promelaAST.promelaCode);
+    writeText(path.join(config.workDir, 'verification.pml'))(promelaAST.promelaCode);
     exec(`spin -a verification.pml`)(config.workDir);
     exec(`gcc -w -o ./pan ./pan.c`)(config.workDir);
     return promelaAST;

--- a/mc-analyzer/src/app/main.ts
+++ b/mc-analyzer/src/app/main.ts
@@ -236,15 +236,19 @@ const config = pipe(
 );
 
 const createPromelaBin = (promelaAST: TPromelaAST) => {
-    // console.log(promelaAST.promelaCode);
-    writeText(path.join(config.workDir, 'verification.pml'))(promelaAST.promelaCode);
+    let code = promelaAST.promelaCode;
+    // Fix empty main proctype for spin
+    if (code.includes('active proctype main() {\n\n}')) {
+        code = code.replace('active proctype main() {\n\n}', 'active proctype main() {\n    skip;\n}');
+    }
+    writeText(path.join(config.workDir, 'verification.pml'))(code);
     exec(`spin -a verification.pml`)(config.workDir);
     exec(`gcc -w -o ./pan ./pan.c`)(config.workDir);
     return promelaAST;
 }
 
 const parseLunaFile = (): LunaAST => {
-    exec(`parser -o ast.json ${config.lunaSourcePath}`)(config.workDir);
+    exec(`${process.env.LUNA_HOME}/bin/parser -o ast.json ${config.lunaSourcePath}`)(config.workDir);
     return pipe(
         path.join(config.workDir, 'ast.json'),
         readFile,

--- a/mc-analyzer/src/app/promela-node/promela-ast-node/proctype-node.ts
+++ b/mc-analyzer/src/app/promela-node/promela-ast-node/proctype-node.ts
@@ -13,7 +13,7 @@ export type TProctypeNode = TPromelaASTNode & {
 
 export const ProctypeNode = (name: string, nodeSequence: readonly TProctypeBodyNode[]): TProctypeNode => {
     const contents = mapArray(getNodeContent)(nodeSequence);
-    const bodyText = joinNewLine(mapArray(addIndent(1))(contents));
+    const bodyText = contents.length === 0 ? "skip;" : joinNewLine(mapArray(addIndent(1))(contents));
     return { nodeSequence, content: `active proctype ${name}() {\n${bodyText}\n}` };
 };
 

--- a/scripts/adapt.py
+++ b/scripts/adapt.py
@@ -142,6 +142,8 @@ def main(
                 print(f'\rRunning mc-analyzer                 \r', end='')
                 subprocess.run(
                     args=[
+                        'npx', 
+                        '--prefix', ADAPT_HOME / 'mc-analyzer', 
                         'ts-node', ADAPT_HOME / 'mc-analyzer' / 'src' / 'app' / 'main.ts',
                         '--project-dir', project_dir,
                         '--build-dir', build_dir,
@@ -196,6 +198,7 @@ def main(
         if not no_cleanup:
             shutil.rmtree(output_dir)
             shutil.rmtree(prolog_analyzer_output_dir)
+            shutil.rmtree(mc_analyzer_output_dir)
             shutil.rmtree(build_dir)
 
     exit(exit_code)


### PR DESCRIPTION
Был немного изменён mc-analyzer:
- в случае пустого тела функции добавляется no-op слово "skip;", чтобы работал spin;
- указан явный путь до парсера luna, так как происходит конфликт с парсером из зависимостей;
- удаление файлов mc-analyzer в случае отсутствия флага --no-cleanup;
- теперь ts-node запускается через npx, чтобы использовать локальные зависимости проекта;
- соответственно, изменён readme, чтобы больше не требовалась глобальная установка зависимостей.